### PR TITLE
[DD-1152] allow ingest on-the-fly processing

### DIFF
--- a/conf/config.properties.template
+++ b/conf/config.properties.template
@@ -37,6 +37,9 @@ transform.do=true
 # enables xml export (from the given output data model)
 export.do=true
 
+# to do ingest on-the-flye at task execution time, you need to disable init and ingest part and provide a valid prototype dataModelID
+task.do_ingest_on_the_fly=true
+
 # results
 
 # (optionally) - only necessary, if transform part is enabled; i.e., task execution result will be stored in the data hub)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>D:SWARM Task Processing Unit</name>
-	<url>http://maven.apache.org</url>
+	<url>https://github.com/dswarm/task-processing-unit-for-dswarm</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- Version des Java Compilers -->
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven-compiler-plugin.version>3.2</maven-compiler-plugin.version>
 		<maven-assembly-plugin.version>2.5.3</maven-assembly-plugin.version>
 		<maven-resources-plugin.version>2.7</maven-resources-plugin.version>

--- a/src/main/java/de/tu_dortmund/ub/data/dswarm/DswarmBackendStatics.java
+++ b/src/main/java/de/tu_dortmund/ub/data/dswarm/DswarmBackendStatics.java
@@ -23,8 +23,9 @@ public final class DswarmBackendStatics {
 
 	public static final String FORMAT_IDENTIFIER = "format";
 
-	public static final String PERSIST_IDENTIFIER            = "persist";
-	public static final String DO_NOT_RETURN_DATA_IDENTIFIER = "do_not_return_data";
-	public static final String DO_INGEST_ON_THE_FLY          = "do_ingest_on_the_fly";
+	public static final String PERSIST_IDENTIFIER                 = "persist";
+	public static final String DO_NOT_RETURN_DATA_IDENTIFIER      = "do_not_return_data";
+	public static final String DO_INGEST_ON_THE_FLY               = "do_ingest_on_the_fly";
 	public static final String DO_VERSIONING_ON_RESULT_IDENTIFIER = "do_versioning_on_result";
+	public static final String DO_DATA_MODEL_INGEST_IDENTIFIER    = "doIngest";
 }

--- a/src/main/java/de/tu_dortmund/ub/data/dswarm/DswarmBackendStatics.java
+++ b/src/main/java/de/tu_dortmund/ub/data/dswarm/DswarmBackendStatics.java
@@ -5,24 +5,25 @@ package de.tu_dortmund.ub.data.dswarm;
  */
 public final class DswarmBackendStatics {
 
-	public static final String DATAMODELS_ENDPOINT          = "datamodels";
-	public static final String RESOURCES_ENDPOINT           = "resources";
-	public static final String CONFIGURATIONS_ENDPOINT        = "configurations";
-	public static final String PROJECTS_ENDPOINT = "projects";
-	public static final String TASKS_ENDPOINT = "tasks";
+	public static final String DATAMODELS_ENDPOINT     = "datamodels";
+	public static final String RESOURCES_ENDPOINT      = "resources";
+	public static final String CONFIGURATIONS_ENDPOINT = "configurations";
+	public static final String PROJECTS_ENDPOINT       = "projects";
+	public static final String TASKS_ENDPOINT          = "tasks";
 
-	public static final String UUID_IDENTIFIER                = "uuid";
-	public static final String MAPPINGS_IDENTIFIER = "mappings";
-	public static final String DATA_RESOURCE_IDENTIFIER = "data_resource";
-	public static final String NAME_IDENTIFIER                = "name";
-	public static final String DESCRIPTION_IDENTIFIER         = "description";
-	public static final String TASK_IDENTIFIER = "task";
-	public static final String JOB_IDENTIFIER = "job";
-	public static final String INPUT_DATA_MODEL_IDENTIFIER = "input_data_model";
+	public static final String UUID_IDENTIFIER              = "uuid";
+	public static final String MAPPINGS_IDENTIFIER          = "mappings";
+	public static final String DATA_RESOURCE_IDENTIFIER     = "data_resource";
+	public static final String NAME_IDENTIFIER              = "name";
+	public static final String DESCRIPTION_IDENTIFIER       = "description";
+	public static final String TASK_IDENTIFIER              = "task";
+	public static final String JOB_IDENTIFIER               = "job";
+	public static final String INPUT_DATA_MODEL_IDENTIFIER  = "input_data_model";
 	public static final String OUTPUT_DATA_MODEL_IDENTIFIER = "output_data_model";
 
 	public static final String FORMAT_IDENTIFIER = "format";
 
-	public static final String PERSIST_IDENTIFIER = "persist";
+	public static final String PERSIST_IDENTIFIER            = "persist";
 	public static final String DO_NOT_RETURN_DATA_IDENTIFIER = "do_not_return_data";
+	public static final String DO_INGEST_ON_THE_FLY          = "do_ingest_on_the_fly";
 }

--- a/src/main/java/de/tu_dortmund/ub/data/dswarm/DswarmBackendStatics.java
+++ b/src/main/java/de/tu_dortmund/ub/data/dswarm/DswarmBackendStatics.java
@@ -26,4 +26,5 @@ public final class DswarmBackendStatics {
 	public static final String PERSIST_IDENTIFIER            = "persist";
 	public static final String DO_NOT_RETURN_DATA_IDENTIFIER = "do_not_return_data";
 	public static final String DO_INGEST_ON_THE_FLY          = "do_ingest_on_the_fly";
+	public static final String DO_VERSIONING_ON_RESULT_IDENTIFIER = "do_versioning_on_result";
 }

--- a/src/main/java/de/tu_dortmund/ub/data/dswarm/TPUStatics.java
+++ b/src/main/java/de/tu_dortmund/ub/data/dswarm/TPUStatics.java
@@ -26,4 +26,5 @@ public final class TPUStatics {
 	public static final String PROTOTYPE_RESOURCE_ID_INDENTIFIER         = "prototype.resourceID";
 	public static final String PERSIST_IN_DMP_IDENTIFIER                 = "results.persistInDMP";
 	public static final String DO_INGEST_ON_THE_FLY_IDENTIFIER           = "task.do_ingest_on_the_fly";
+	public static final String DO_INITIAL_DATA_MODEL_INGEST_IDENTIFIER   = "init.data_model.do_ingest";
 }

--- a/src/main/java/de/tu_dortmund/ub/data/dswarm/TPUStatics.java
+++ b/src/main/java/de/tu_dortmund/ub/data/dswarm/TPUStatics.java
@@ -12,7 +12,6 @@ public final class TPUStatics {
 	public static final String PROTOTYPE_INPUT_DATA_MODEL_ID_IDENTIFIER  = "prototype.dataModelID";
 	public static final String PROJECT_NAME_IDENTIFIER                   = "project.name";
 	public static final String CONFIGURATION_NAME_IDENTIFIER             = "configuration.name";
-	public static final String INIT_RESOURCE_NAME_IDENTIFIER             = "resource.initresource";
 	public static final String ENGINE_DSWARM_API_IDENTIFIER              = "engine.dswarm.api";
 	public static final String ENGINE_DSWARM_GRAPH_API_IDENTIFIER        = "engine.dswarm.graph.api";
 	public static final String DO_EXPORT_IDENTIFIER                      = "export.do";
@@ -26,4 +25,5 @@ public final class TPUStatics {
 	public static final String PROTOTYPE_PROJECT_IDS_INDENTIFIER         = "prototype.projectIDs";
 	public static final String PROTOTYPE_RESOURCE_ID_INDENTIFIER         = "prototype.resourceID";
 	public static final String PERSIST_IN_DMP_IDENTIFIER                 = "results.persistInDMP";
+	public static final String DO_INGEST_ON_THE_FLY_IDENTIFIER           = "task.do_ingest_on_the_fly";
 }

--- a/src/main/java/de/tu_dortmund/ub/data/dswarm/Transform.java
+++ b/src/main/java/de/tu_dortmund/ub/data/dswarm/Transform.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -98,13 +99,24 @@ public class Transform implements Callable<String> {
 
 		final String serviceName = config.getProperty(TPUStatics.SERVICE_NAME_IDENTIFIER);
 		final String engineDswarmAPI = config.getProperty(TPUStatics.ENGINE_DSWARM_API_IDENTIFIER);
+		final String doIngestOnTheFlyString = config.getProperty(TPUStatics.DO_INGEST_ON_THE_FLY_IDENTIFIER);
+		final Optional<Boolean> optionalDoIngestOnTheFly;
+
+		if (doIngestOnTheFlyString != null && !doIngestOnTheFlyString.trim().isEmpty()) {
+
+			optionalDoIngestOnTheFly = Optional.of(Boolean.valueOf(doIngestOnTheFlyString));
+		} else {
+
+			optionalDoIngestOnTheFly = Optional.empty();
+		}
 
 		logger.info(String.format("[%s] Starting 'Transform (Task)' ...", serviceName));
 
 		try {
 
 			// export and save to results folder
-			final String response = executeTask(inputDataModelID, projectIDs, outputDataModelID, serviceName, engineDswarmAPI);
+			final String response = executeTask(inputDataModelID, projectIDs, outputDataModelID, serviceName, engineDswarmAPI,
+					optionalDoIngestOnTheFly);
 			logger.debug(String.format("task execution result = '%s'", response));
 
 			return response;
@@ -126,8 +138,7 @@ public class Transform implements Callable<String> {
 	 * @return
 	 */
 	private String executeTask(final String inputDataModelID, final Collection<String> projectIDs, final String outputDataModelID,
-			final String serviceName,
-			final String engineDswarmAPI) throws Exception {
+			final String serviceName, final String engineDswarmAPI, final Optional<Boolean> optionalDoIngestOnTheFly) throws Exception {
 
 		final JsonArray mappings = getMappingsFromProjects(projectIDs, serviceName, engineDswarmAPI);
 		final JsonObject inputDataModel = getDataModel(inputDataModelID, serviceName, engineDswarmAPI);
@@ -153,6 +164,13 @@ public class Transform implements Callable<String> {
 		jp.write(DswarmBackendStatics.PERSIST_IDENTIFIER, persist);
 		// default for now: true, i.e., no content will be returned
 		jp.write(DswarmBackendStatics.DO_NOT_RETURN_DATA_IDENTIFIER, true);
+
+		if (optionalDoIngestOnTheFly.isPresent()) {
+
+			logger.info(String.format("[%s] do ingest on-the-fly", serviceName));
+
+			jp.write(DswarmBackendStatics.DO_INGEST_ON_THE_FLY, optionalDoIngestOnTheFly.get());
+		}
 
 		// task
 		jp.writeStartObject(DswarmBackendStatics.TASK_IDENTIFIER);

--- a/src/main/java/de/tu_dortmund/ub/data/dswarm/Transform.java
+++ b/src/main/java/de/tu_dortmund/ub/data/dswarm/Transform.java
@@ -172,6 +172,8 @@ public class Transform implements Callable<String> {
 			jp.write(DswarmBackendStatics.DO_INGEST_ON_THE_FLY, optionalDoIngestOnTheFly.get());
 		}
 
+		jp.write(DswarmBackendStatics.DO_VERSIONING_ON_RESULT_IDENTIFIER, false);
+
 		// task
 		jp.writeStartObject(DswarmBackendStatics.TASK_IDENTIFIER);
 		jp.write(DswarmBackendStatics.NAME_IDENTIFIER, "Task Batch-Prozess 'CrossRef'");


### PR DESCRIPTION
should work with https://github.com/zazi/dswarm/tree/sprint-41/dd-1152

usage:

`# to disable data ingest to data hub at data model creation`
init.data_model.do_ingest=false

`# to enable data ingest on-the-fly at task execution`
task.do_ingest_on_the_fly=true
